### PR TITLE
Missing the O in shortmess to avoid press enter prompts when doing a diff

### DIFF
--- a/plugin/default.vim
+++ b/plugin/default.vim
@@ -41,7 +41,7 @@ if !has('nvim')
 
 endif
 
-set shortmess=atI  " No help Uganda information
+set shortmess=atOI  " No help Uganda information, and overwrite read messages to avoid "PRESS ENTER" prompts
 set ignorecase     " Case sensitive search
 set smartcase      " Case sensitive when uc present
 set scrolljump=5   " Line to scroll when cursor leaves screen


### PR DESCRIPTION
Without the O prompt, if you use vimdiff, you end up getting an annoying display of the two files you're editing, plus "PRESS ENTER TO CONTINUE".  The O flag overwrites any read messages from the commandline, making it smoother to get into diff mode.