### PR TITLE
Add cursor shape handling for neovim.

### DIFF
--- a/plugin/default.vim
+++ b/plugin/default.vim
@@ -114,6 +114,12 @@ command! W w !sudo tee % > /dev/null
     let &t_SR = "\<Esc>Ptmux;\<Esc>\<Esc>]50;CursorShape=2\x7\<Esc>\\"
     let &t_EI = "\<Esc>Ptmux;\<Esc>\<Esc>]50;CursorShape=0\x7\<Esc>\\"
   endif
+
+  " inside neovim
+  if has('nvim')
+    let $NVIM_TUI_ENABLE_TRUE_COLOR=1
+    let $NVIM_TUI_ENABLE_CURSOR_SHAPE=1
+  endif
 " }
 
 if exists('g:vim_better_default_minimum') && g:vim_better_default_minimum

--- a/plugin/default.vim
+++ b/plugin/default.vim
@@ -117,8 +117,7 @@ command! W w !sudo tee % > /dev/null
 
   " inside neovim
   if has('nvim')
-    let $NVIM_TUI_ENABLE_TRUE_COLOR=1
-    let $NVIM_TUI_ENABLE_CURSOR_SHAPE=1
+    let $NVIM_TUI_ENABLE_CURSOR_SHAPE=2
   endif
 " }
 


### PR DESCRIPTION
vim-better-defaults has cursor shape configurations for iterm and tmux, but these do not work in neovim.

Neovim's uses a different way to configure cursor shapes.
This change adds cursor shape config for neovim.  