### PR TITLE
Fix shell open failed in neovim

### DIFF
--- a/plugin/default.vim
+++ b/plugin/default.vim
@@ -243,7 +243,7 @@ endif
         " Auto indent pasted text
         " nnoremap p p=`]<C-o>
         " Open shell in vim
-        if has('terminal')
+        if has('nvim') || has('terminal')
           map <Leader>' :terminal<CR>
         else
           map <Leader>' :shell<CR>


### PR DESCRIPTION
Discussion in liuchengxu/space-vim#195, change if-condition to
has('nvim') || has('terminal') to support both neovim and vim 8+.

Signed-off-by: jensenzhang <jingxuan.n.zhang@gmail.com>