### PR TITLE
Fix bugs in `set fileencodings`

### DIFF
--- a/plugin/default.vim
+++ b/plugin/default.vim
@@ -80,7 +80,7 @@ set whichwrap+=<,>,h,l  " Allow backspace and cursor keys to cross line boundari
 
 set termencoding=utf-8
 set fileencoding=utf-8
-set fileencodings=utf-8,ucs-bom,gb18030,gbk,gb2312,cp936
+set fileencodings=ucs-bom,utf-8,default,gb18030,gbk,gb2312,cp936,latin1
 
 set wildignore+=*swp,*.class,*.pyc,*.png,*.jpg,*.gif,*.zip
 set wildignore+=*/tmp/*,*.o,*.obj,*.so     " Unix


### PR DESCRIPTION
I [ran into issues](https://github.com/OmniSharp/omnisharp-vim/issues/781) when making a C# layer for *space-vim* and traced the problem to this plugin.

Reasoning for changes below:

See `help fileencodings`:

> The special value "ucs-bom" can be used to check for a Unicode BOM
(Byte Order Mark) at the start of the file.  ***It must not be preceded
by "utf-8"*** or another Unicode encoding for this to work properly.
```
	WRONG VALUES:			WHAT'S WRONG:
		utf-8,ucs-bom,latin1	BOM won't be recognized in an utf-8
					file
```
`ucs-bom` must come before `utf-8` or other Unicode encodings. This was the bug causing problems in the C# layer for *space-vim* I'm making.

> The special value "default" can be used for the encoding from the environment.  This is the default value for 'encoding'.  It is useful when 'encoding' is set to "utf-8" and your environment uses a non-latin1 encoding, such as Russian.

`default` seems reasonable to include. This wasn't a bug I noticed, but, it seems reasonable.

The ordering of `default` might matter, so consider testing the changes, but I assume it is OK as-is in this PR:
```
	WRONG VALUES:			WHAT'S WRONG:
		latin1,utf-8		"latin1" will always be used
		utf-8,ucs-bom,latin1	BOM won't be recognized in an utf-8
					file
		cp1250,latin1		"cp1250" will always be used
```

> An entry for an 8-bit encoding (e.g., "latin1") should be the last, because Vim cannot detect an error, thus the encoding is always accepted.

`cp936` is a [two byte encoding](https://www.iana.org/assignments/charset-reg/GBK) and was last in `set fileencodings`, which looks like a bug to me as the `fileencodings` documentation says an 8-bit encoding should be last. `latin1` is 8-bits, and is by default the last in `fileencodings`, so I appended it to make it last.

`cp936` [is an alias for](https://www.iana.org/assignments/charset-reg/GBK) `gbk`, so they're redundant. But I didn't delete one or the other as I can't test, but will point this out to you if you want to make that change.

[This](https://www.iana.org/assignments/character-sets/character-sets.xhtml) is a good reference describing details on the different character sets.

I assume in Vim `ucs-bom` reads the [Byte Order Mark (BOM)](https://en.wikipedia.org/wiki/Byte_order_mark) from the beginning of the file and determines that the file is Unicode from that if it is there, otherwise Vim tries the subsequent encodings in `fileencodings` one by one until the file contains no illegal (non-printable) byte sequences? I assume that's how it works. And the last one `latin1` is a catch-all which never fails to parse, which might display funky characters (non printable characters) if the file didn't have a BOM and the right encoding wasn't in the `fileencodings`.
> When a file is read, Vim tries to use the first mentioned character encoding.  If an error is detected, the next one in the list is tried.  When an encoding is found that works, 'fileencoding' is set to it.  If all fail, 'fileencoding' is set to an empty string, which means the value of 'encoding' is used.

Looks like I'm thinking right `:help bomb`:
> When Vim reads a file and 'fileencodings' starts with "ucs-bom", a check for the presence of the BOM is done and 'bomb' set accordingly.

**EDIT:** I don't know much about Chinese encodings. I assume a Unicode BOM in the file would be enough for Vim to detect/handle `gb18030`, but if there is no BOM in the file then I assume it's good to have `gb18030` in `fileencodings`. `gb18030` should also parse the two non-Unicode encodings (`gb2312` and `gbk/cp936`). So I assume the minimal line could be `ucs-bom,utf-8,default,gb18030,latin1`. You'd know better than me though.
> [GB18030](https://www.iana.org/assignments/charset-reg/GB18030) In a nutshell, it is the Chinese version of UTF-8: whereas UTF-8 maintains compatibility with ASCII, GB18030 maintains compatibility with GB2312/GBK